### PR TITLE
use lineinfile module over shell + sed

### DIFF
--- a/kubespray/roles/packages/tasks/main.yml
+++ b/kubespray/roles/packages/tasks/main.yml
@@ -6,7 +6,7 @@
 - name: Update All Packages
   package:
     name: '*'
-    state: latest 
+    state: latest
 
 - name: Removing required packages
   package:
@@ -24,7 +24,10 @@
     state: present
 
 - name: 'Enable Automatic Updates - Auto Apply = True'
-  shell: "sed -i 's/^apply_updates = no/apply_updates = yes/g' /etc/dnf/automatic.conf"
+  lineinfile:
+    path: /etc/dnf/automatic.conf
+    regexp: "^apply_updates = no"
+    line: "apply_updates = yes"
 
 - name: Enable DNF Automatic Update Service
   systemd:


### PR DESCRIPTION
```
TASK [containercraft.kubespray.packages : Enable Automatic Updates - Auto Apply = True] ***********************************************************
[WARNING]: Consider using the replace, lineinfile or template module
rather than running 'sed'.  If you need to use command because replace,
lineinfile or template is insufficient you can add 'warn: false' to this
command task or set 'command_warnings=False' in ansible.cfg to get rid
of this message.
```
remove extra whitespace
